### PR TITLE
black (auto code formatter) pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,4 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
     rev: 19.3b0
     hooks:


### PR DESCRIPTION
In order to guarantee code readability, we should follow the PEP-8 style guidelines.
There are many code formatters that can do this automatically (e.g. black, yapf, autopep8).

I would also propose to use a pre-commit-hook that runs black automatically before any commit is being made (so you don't forget).
Keep in mind that if black has to make changes to your python scripts, you will have to stage those changes again before you can commit. (this could be done automatically, but is generally considered bad practice)

you will have to install **black** and **pre-commit** packages using 
`pip install black`
`pip install pre-commit`

and then install our **.pre-commit-config.yaml** hook with the command
`pre-commit install`

Let me know if you run into any issues. You can also find more info on their websites:
[https://black.readthedocs.io/en/stable/the_black_code_style.html](https://black.readthedocs.io/en/stable/the_black_code_style.html)
[https://pre-commit.com/](https://pre-commit.com/)




